### PR TITLE
Set debug as instance attribute

### DIFF
--- a/src/elliptec/controller.py
+++ b/src/elliptec/controller.py
@@ -22,6 +22,7 @@ class Controller:
                  timeout=2, 
                  write_timeout=0.5, 
                  debug=True):
+        self.debug = debug
         if port == None: 
             self.__search_and_connect(baudrate, 
                                       bytesize, 


### PR DESCRIPTION
Hey, great project.

Not really sure if this is still actively mantained but this PR sets `self.debug` in the `elliptect.controller.Controller` class.
In some code sections it is referenced, but when using the controller, `AttributeError` is raised due to the fact that the local attribute is not declared in the first plase.

As a tip, you should probably consider setting up a `Logger` instance rather than using `prints`, since it's more intuitive and doesn't require to pass a `debug` flag which instead you can control directly by setting `logging.setLevel("DEBUG")`. But it's out of scope of this PR