### PR TITLE
Repository polish: type hints, logging, and API cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@
     ·
     <a href="https://github.com/roesel/elliptec/issues">Request a feature</a>
   </p>
+
+  <p align="center">
+    <a href="https://pypi.org/project/elliptec/"><img alt="PyPI" src="https://img.shields.io/pypi/v/elliptec"></a>
+    <a href="https://pypi.org/project/elliptec/"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/elliptec"></a>
+    <a href="https://github.com/roesel/elliptec/actions/workflows/ruff.yml"><img alt="Ruff" src="https://github.com/roesel/elliptec/actions/workflows/ruff.yml/badge.svg"></a>
+    <a href="https://elliptec.readthedocs.io/en/latest/?badge=latest"><img alt="Docs" src="https://readthedocs.org/projects/elliptec/badge/?version=latest"></a>
+    <a href="https://github.com/roesel/elliptec/blob/main/LICENSE"><img alt="License: GPL v3" src="https://img.shields.io/badge/License-GPLv3-blue.svg"></a>
+  </p>
 </div>
 
 <!-- ABOUT THE PROJECT -->
@@ -118,7 +126,7 @@ rotator = elliptec.Rotator(controller, address='2')
 # Home the shutter and the rotator
 shutter.home() 
 rotator.home()
-# Loop over a list of angles and opne/acquire/close for each
+# Loop over a list of angles and open/acquire/close for each
 for angle in [0, 90]:
     rotator.set_angle(angle)
     # Open shutter, acquire, and close again
@@ -169,7 +177,7 @@ Some of the missing functionality can be performed using the official [Elliptec&
 ## Support
 If you are going to use this code in any way, **please let me know** via [email](mailto:roesel@gmail.com)/[twitter](https://twitter.com/DavidRoesel)/[issues](https://github.com/roesel/elliptec/issues) or find my contact info on [my website](https://david.roesel.cz/en/). I am working on this project in my spare time and need every piece of encouragement I can get! If this project was useful to you, please consider buying me a coffee ;).
 
-<a href='https://ko-fi.com/roesel' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' />
+<a href='https://ko-fi.com/roesel' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 ## Disclaimer
 Thorlabs&trade; and Elliptec&trade; are registered trademarks of Thorlabs,&nbsp;Inc. This project is fully non-commercial and not affiliated with Thorlabs,&nbsp;Inc. in any capacity. 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,11 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'elliptec'
-copyright = '2022, David Roesel'
+copyright = '2022-2025, David Roesel'
 author = 'David Roesel'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '0.0.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,7 +87,7 @@ An advanced example, which shows how to control multiple devices plugged into on
    # Home the shutter and the rotator
    sh.home() 
    ro.home()
-   # Loop over a list of angles and opne/acquire/close for each
+   # Loop over a list of angles and open/acquire/close for each
    for angle in [0, 90]:
        ro.set_angle(angle)
        # Open shutter, acquire, and close again

--- a/src/elliptec/__init__.py
+++ b/src/elliptec/__init__.py
@@ -3,7 +3,6 @@ from .cmd import commands
 from .devices import devices
 from .errors import ExternalDeviceNotFound
 from .scan import find_ports, scan_for_devices
-from .tools import is_null_or_empty, parse, s32, error_check, move_check
 
 # Classes for controllers
 from .controller import Controller
@@ -33,9 +32,4 @@ __all__ = [
     "Iris",
     "find_ports",
     "scan_for_devices",
-    "is_null_or_empty",
-    "parse",
-    "s32",
-    "error_check",
-    "move_check",
 ]

--- a/src/elliptec/cmd.py
+++ b/src/elliptec/cmd.py
@@ -1,10 +1,11 @@
-""" This file contains a dictionary of commands that the devices can accept in 
-three different categories: get, set, move. For each command, it returns the 
+""" This file contains a dictionary of commands that the devices can accept in
+three different categories: get, set, move. For each command, it returns the
 instruction code to send to the device. """
+from __future__ import annotations
 
 # TODO: Each type of device should get it's own list of supported commands.
 
-get_ = {
+get_: dict[str, bytes] = {
     "info": b"in",
     "status": b"gs",
     "position": b"gp",
@@ -14,9 +15,9 @@ get_ = {
     "motor_2_info": b"i2",
 }
 
-set_ = {"stepsize": b"sj", "isolate": b"is", "address": b"ca", "home_offset": b"so"}
+set_: dict[str, bytes] = {"stepsize": b"sj", "isolate": b"is", "address": b"ca", "home_offset": b"so"}
 
-mov_ = {
+mov_: dict[str, bytes] = {
     "home_clockwise": b"ho0",
     "home_anticlockwise": b"ho1",
     "forward": b"fw",
@@ -25,11 +26,11 @@ mov_ = {
     "relative": b"mr",
 }
 
-do_ = {
+do_: dict[str, bytes] = {
     "save_user_data": b"us",
     }
 
 
-def commands():
+def commands() -> dict[str, dict[str, bytes]]:
     """Returns a dictionary of commands that the devices can accept."""
     return {"get": get_, "set": set_, "move": mov_, "do": do_}

--- a/src/elliptec/continuous.py
+++ b/src/elliptec/continuous.py
@@ -1,6 +1,8 @@
 """Base class for continuous-position motors (rotators, linear stages, irises)."""
 from __future__ import annotations
 
+from abc import abstractmethod
+
 from .motor import Motor
 from .tools import Status
 
@@ -13,11 +15,13 @@ class ContinuousMotor(Motor):
         _unit_to_pos(value) -> int: Convert user unit to pulse position
     """
 
+    @abstractmethod
     def _pos_to_unit(self, position: int) -> float:
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def _unit_to_pos(self, value: float) -> int:
-        raise NotImplementedError
+        ...
 
     def _get_unit(self) -> float | None:
         """Gets the current position in user units."""

--- a/src/elliptec/continuous.py
+++ b/src/elliptec/continuous.py
@@ -1,5 +1,8 @@
 """Base class for continuous-position motors (rotators, linear stages, irises)."""
+from __future__ import annotations
+
 from .motor import Motor
+from .tools import Status
 
 
 class ContinuousMotor(Motor):
@@ -10,57 +13,57 @@ class ContinuousMotor(Motor):
         _unit_to_pos(value) -> int: Convert user unit to pulse position
     """
 
-    def _pos_to_unit(self, position):
+    def _pos_to_unit(self, position: int) -> float:
         raise NotImplementedError
 
-    def _unit_to_pos(self, value):
+    def _unit_to_pos(self, value: float) -> int:
         raise NotImplementedError
 
-    def _get_unit(self):
+    def _get_unit(self) -> float | None:
         """Gets the current position in user units."""
         status = self.get("position")
         return self._extract_unit_from_status(status)
 
-    def _set_unit(self, value):
+    def _set_unit(self, value: float) -> float | None:
         """Moves to an absolute position in user units."""
         position = self._unit_to_pos(value)
         status = self.move("absolute", position)
         return self._extract_unit_from_status(status)
 
-    def _shift_unit(self, value):
+    def _shift_unit(self, value: float) -> float | None:
         """Shifts by a relative amount in user units."""
         position = self._unit_to_pos(value)
         status = self.move("relative", position)
         return self._extract_unit_from_status(status)
 
-    def jog(self, direction="forward"):
+    def jog(self, direction: str = "forward") -> float | None:
         """Jogs by the jog distance in a particular direction."""
         if direction in ["backward", "forward"]:
             status = self.move(direction)
             return self._extract_unit_from_status(status)
         return None
 
-    def get_home_offset(self):
+    def get_home_offset(self) -> float | None:
         """Gets the home offset."""
         status = self.get("home_offset")
         return self._extract_unit_from_status(status)
 
-    def set_home_offset(self, offset):
+    def set_home_offset(self, offset: float) -> Status | None:
         """Sets the home offset."""
         position = self._unit_to_pos(offset)
         return self.set("home_offset", position)
 
-    def get_jog_step(self):
+    def get_jog_step(self) -> float | None:
         """Gets the jog step."""
         status = self.get("stepsize")
         return self._extract_unit_from_status(status)
 
-    def set_jog_step(self, value):
+    def set_jog_step(self, value: float) -> Status | None:
         """Sets the jog step size."""
         position = self._unit_to_pos(value)
         return self.set("stepsize", position)
 
-    def _extract_unit_from_status(self, status):
+    def _extract_unit_from_status(self, status: Status | None) -> float | None:
         """Extracts user-unit value from a status tuple."""
         if status and status[1] in ["PO", "HO", "GJ"]:
             return self._pos_to_unit(int(status[2]))

--- a/src/elliptec/iris.py
+++ b/src/elliptec/iris.py
@@ -1,38 +1,41 @@
 """Module for motorized iris (ELL15). Inherits from elliptec.ContinuousMotor."""
+from __future__ import annotations
+
 from .continuous import ContinuousMotor
 from .devices import devices
+from .tools import Status
 
 
 class Iris(ContinuousMotor):
     """Iris class for elliptec motorized iris."""
 
-    def check_move(self, target_aperture):
+    def check_move(self, target_aperture: float) -> bool:
         min_aperture = devices[self.motor_type]["min_aperture"]
         max_aperture = devices[self.motor_type]["max_aperture"]
         return min_aperture <= target_aperture <= max_aperture
 
-    def _pos_to_unit(self, position):
+    def _pos_to_unit(self, position: int) -> float:
         """Converts position in pulses to aperture in millimeters."""
         pulse_range = self.pulse_per_rev * self.range
         return round(position / pulse_range * self.range, 4)
 
-    def _unit_to_pos(self, value):
+    def _unit_to_pos(self, value: float) -> int:
         """Converts aperture in millimeters to position in pulses."""
         pulse_range = self.pulse_per_rev * self.range
         return int(value / self.range * pulse_range)
 
     # Public API (with bounds checking)
-    def get_aperture(self):
+    def get_aperture(self) -> float | None:
         """Finds at which aperture the iris is at the moment."""
         return self._get_unit()
 
-    def set_aperture(self, aperture):
+    def set_aperture(self, aperture: float) -> float | None:
         """Moves to a particular aperture."""
         if self.check_move(aperture):
             return self._set_unit(aperture)
         return None
 
-    def shift_aperture(self, distance):
+    def shift_aperture(self, distance: float) -> float | None:
         """Shifts by a particular amount."""
         current_aperture = self.get_aperture()
         target_aperture = current_aperture + distance
@@ -41,14 +44,14 @@ class Iris(ContinuousMotor):
         return None
 
     # Backward compatibility aliases
-    def extract_aperture_from_status(self, status):
+    def extract_aperture_from_status(self, status: Status | None) -> float | None:
         """Extracts aperture from status."""
         return self._extract_unit_from_status(status)
 
-    def pos_to_dist(self, position):
+    def pos_to_dist(self, position: int) -> float:
         """Converts position in pulses to aperture in millimeters."""
         return self._pos_to_unit(position)
 
-    def dist_to_pos(self, aperture):
+    def dist_to_pos(self, aperture: float) -> int:
         """Converts aperture in millimeters to position in pulses."""
         return self._unit_to_pos(aperture)

--- a/src/elliptec/linear.py
+++ b/src/elliptec/linear.py
@@ -1,42 +1,45 @@
 """Module for linear stages. Inherits from elliptec.ContinuousMotor."""
+from __future__ import annotations
+
 from .continuous import ContinuousMotor
+from .tools import Status
 
 
 class Linear(ContinuousMotor):
     """Elliptec Linear Motor class."""
 
-    def _pos_to_unit(self, position):
+    def _pos_to_unit(self, position: int) -> float:
         """Converts position in pulses to distance in millimeters."""
         pulse_range = self.pulse_per_rev * self.range
         return round(position / pulse_range * self.range, 4)
 
-    def _unit_to_pos(self, value):
+    def _unit_to_pos(self, value: float) -> int:
         """Converts distance in millimeters to position in pulses."""
         pulse_range = self.pulse_per_rev * self.range
         return int(value / self.range * pulse_range)
 
     # Public API
-    def get_distance(self):
+    def get_distance(self) -> float | None:
         """Finds at which distance the stage is at the moment."""
         return self._get_unit()
 
-    def set_distance(self, distance):
+    def set_distance(self, distance: float) -> float | None:
         """Moves to a particular distance."""
         return self._set_unit(distance)
 
-    def shift_distance(self, distance):
+    def shift_distance(self, distance: float) -> float | None:
         """Shifts by a particular distance."""
         return self._shift_unit(distance)
 
     # Backward compatibility aliases
-    def extract_distance_from_status(self, status):
+    def extract_distance_from_status(self, status: Status | None) -> float | None:
         """Extracts distance from status."""
         return self._extract_unit_from_status(status)
 
-    def pos_to_dist(self, position):
+    def pos_to_dist(self, position: int) -> float:
         """Converts position in pulses to distance in millimeters."""
         return self._pos_to_unit(position)
 
-    def dist_to_pos(self, distance):
+    def dist_to_pos(self, distance: float) -> int:
         """Converts distance in millimeters to position in pulses."""
         return self._unit_to_pos(distance)

--- a/src/elliptec/motor.py
+++ b/src/elliptec/motor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from abc import ABC
 from collections.abc import Callable
 
 from .cmd import get_, set_, mov_, do_
@@ -12,7 +13,7 @@ from .errors import ExternalDeviceNotFound
 logger = logging.getLogger(__name__)
 
 
-class Motor:
+class Motor(ABC):
     """A class that represents a general motor. Each device inherits from this class."""
 
     def __init__(self, controller: Controller, address: str = "0", debug: bool = True) -> None:

--- a/src/elliptec/motor.py
+++ b/src/elliptec/motor.py
@@ -1,25 +1,33 @@
 """A module that contains the Motor class, which is the base class for all motors."""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
 from .cmd import get_, set_, mov_, do_
-from .tools import error_check, move_check
+from .controller import Controller
+from .tools import Status, error_check, move_check
 from .errors import ExternalDeviceNotFound
+
+logger = logging.getLogger(__name__)
 
 
 class Motor:
     """A class that represents a general motor. Each device inherits from this class."""
 
-    def __init__(self, controller, address="0", debug=True):
+    def __init__(self, controller: Controller, address: str = "0", debug: bool = True) -> None:
         # the controller object which services the COM port
         self.controller = controller
         # self.address is kept as a 0-F string and encoded in send_instruction()
         self.address = address
         self.debug = debug
 
-        self.last_position = None
+        self.last_position: int | str | None = None
 
         # Load motor info on creation
         self.load_motor_info()
 
-    def load_motor_info(self):
+    def load_motor_info(self) -> None:
         """Asks motor for info and load response into properties other methods can check later."""
         info = self.get("info")
         if info is None:
@@ -33,24 +41,24 @@ class Motor:
             self.serial_no = self.info["Serial No."]
             self.motor_type = self.info["Motor Type"]
 
-    def send_instruction(self, instruction, message=None):
+    def send_instruction(self, instruction: bytes, message: int | str | None = None) -> Status | None:
         """Sends an instruction to the motor. Returns the response from the motor."""
         response = self.controller.send_instruction(instruction, address=self.address, message=message)
 
         return response
 
     # Action functions
-    def _execute(self, command_dict, req, data=None, check_fn=error_check):
+    def _execute(self, command_dict: dict[str, bytes], req: str, data: int | str | None = None, check_fn: Callable[[Status | None], None] = error_check) -> Status | None:
         """Looks up and executes a command from the given dictionary."""
         if req not in command_dict:
-            print(f"Invalid Command: {req}")
+            logger.error("Invalid Command: %s", req)
             return None
         status = self.send_instruction(command_dict[req], message=data)
         if self.debug:
             check_fn(status)
         return status
 
-    def move(self, req="home", data=""):
+    def move(self, req: str = "home", data: int | str = "") -> Status | None | bool:
         """Wrapper function to easily enable access to movement.
         Expects:
         req - Name of request
@@ -58,7 +66,7 @@ class Motor:
         """
         # Try to translate command to instruction
         if req not in mov_:
-            print(f"Invalid Command: {req}")
+            logger.error("Invalid Command: %s", req)
             return False
 
         instruction = mov_[req]
@@ -73,27 +81,27 @@ class Motor:
             move_check(status)
         return status
 
-    def get(self, req="status", data=""):
+    def get(self, req: str = "status", data: int | str = "") -> Status | None:
         """Generates get instructions from commands."""
         return self._execute(get_, req, data=data)
 
-    def set(self, req="", data=""):
+    def set(self, req: str = "", data: int | str = "") -> Status | None:
         """Generates set instructions from commands."""
         return self._execute(set_, req, data=data)
 
-    def do(self, req=""):
+    def do(self, req: str = "") -> Status | None:
         """Generates do instructions from commands."""
         return self._execute(do_, req)
 
     # Wrapper functions
-    def home(self, clockwise=True):
+    def home(self, clockwise: bool = True) -> Status | None | bool:
         """Wrapper function to easily enable access to homing."""
         if clockwise:
             return self.move("home_clockwise")
         else:
             return self.move("home_anticlockwise")
 
-    def change_address(self, new_address):
+    def change_address(self, new_address: str) -> None:
         """Changes the address of the motor."""
         old_address = self.address
         status = self.set("address", data=new_address)
@@ -101,9 +109,9 @@ class Motor:
             # Make the Motor object know about the change
             self.address = new_address
             if self.debug:
-                print(f"Address successfully changed from {old_address} to {new_address}.")
+                logger.debug("Address successfully changed from %s to %s.", old_address, new_address)
 
-    def save_user_data(self):
+    def save_user_data(self) -> None:
         """Saves the user data to the motor."""
         self.do("save_user_data")
 
@@ -114,10 +122,10 @@ class Motor:
     # save_user_status(self, motor)
 
     ## Private methods
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns a string representation of the motor."""
         return "".join(f"{key} - {self.info[key]}\n" for key in self.info)
 
-    def close_connection(self):
+    def close_connection(self) -> None:
         """Closes the serial port."""
         self.controller.close_connection()

--- a/src/elliptec/rotator.py
+++ b/src/elliptec/rotator.py
@@ -1,40 +1,43 @@
 """Module for rotation mount (ELL14) or rotary stage (ELL18). Inherits from elliptec.ContinuousMotor."""
+from __future__ import annotations
+
 from .continuous import ContinuousMotor
+from .tools import Status
 
 
 class Rotator(ContinuousMotor):
     """Class for rotation mounts such as a rotating mount (ELL14) or rotary stage (ELL18)."""
 
-    def _pos_to_unit(self, position):
+    def _pos_to_unit(self, position: int) -> float:
         """Converts position in pulses to angle in degrees."""
         return round(position / self.pulse_per_rev * self.range, 4)
 
-    def _unit_to_pos(self, value):
+    def _unit_to_pos(self, value: float) -> int:
         """Converts angle in degrees to position in pulses."""
         return int(value / self.range * self.pulse_per_rev)
 
     # Public API
-    def get_angle(self):
+    def get_angle(self) -> float | None:
         """Finds at which angle (in degrees) the rotator is at the moment."""
         return self._get_unit()
 
-    def set_angle(self, angle):
+    def set_angle(self, angle: float) -> float | None:
         """Moves the rotator to a particular angle (in degrees)."""
         return self._set_unit(angle)
 
-    def shift_angle(self, angle):
+    def shift_angle(self, angle: float) -> float | None:
         """Shifts by a particular angle (in degrees)."""
         return self._shift_unit(angle)
 
     # Backward compatibility aliases
-    def extract_angle_from_status(self, status):
+    def extract_angle_from_status(self, status: Status | None) -> float | None:
         """Extracts angle from status."""
         return self._extract_unit_from_status(status)
 
-    def pos_to_angle(self, posval):
+    def pos_to_angle(self, posval: int) -> float:
         """Converts position in pulses to angle in degrees."""
         return self._pos_to_unit(posval)
 
-    def angle_to_pos(self, angleval):
+    def angle_to_pos(self, angleval: float) -> int:
         """Converts angle in degrees to position in pulses."""
         return self._unit_to_pos(angleval)

--- a/src/elliptec/scan.py
+++ b/src/elliptec/scan.py
@@ -1,15 +1,20 @@
 """Module for scanning for Elliptec devices."""
+from __future__ import annotations
 
+import logging
 
 import serial as s
 import serial.tools.list_ports as listports
+from .controller import Controller
 from .errors import ExternalDeviceNotFound
 from .motor import Motor
+
+logger = logging.getLogger(__name__)
 
 # Scanning functions
 
 
-def find_ports():
+def find_ports() -> list[str]:
     """Find all available ports with an Elliptec device connected."""
     avail_ports = []
     for port in listports.comports():
@@ -19,18 +24,18 @@ def find_ports():
                 connection.close()
                 avail_ports.append(port)
             except (OSError, s.SerialException):
-                print(f"{port.device} unavailable.\n")
+                logger.warning("%s unavailable.", port.device)
     port_names = [port.device for port in avail_ports]
     return port_names
 
 
-def scan_for_devices(controller, start_address=0, stop_address=0, debug=True):
+def scan_for_devices(controller: Controller, start_address: int = 0, stop_address: int = 0, debug: bool = True) -> list[dict[str, object]]:
     """Scan for devices on a controller. Returns a list of dictionaries with device info and controller object."""
-    devices = []
+    devices: list[dict[str, object]] = []
     for address in range(start_address, stop_address + 1):
         try:
             motor = Motor(controller, address=str(address), debug=debug)
-            print(f"{controller.port}, address {address}: ELL{motor.motor_type} \t(S/N: {motor.serial_no})")
+            logger.info("%s, address %s: ELL%s \t(S/N: %s)", controller.port, address, motor.motor_type, motor.serial_no)
             device = {
                 "info": motor.info,
                 "controller": controller,

--- a/src/elliptec/shutter.py
+++ b/src/elliptec/shutter.py
@@ -1,26 +1,29 @@
 """Module for shutter. Inherits from elliptec.Motor."""
+from __future__ import annotations
 
+from .controller import Controller
 from .devices import devices
+from .tools import Status
 from . import Motor
 
 
 class Shutter(Motor):
     """Class for shutter objects, typically two-position linear sliders. Inherits from elliptec.Motor."""
 
-    def __init__(self, controller, address="0", debug=True, inverted=False):
+    def __init__(self, controller: Controller, address: str = "0", debug: bool = True, inverted: bool = False) -> None:
         super().__init__(controller=controller, address=address, debug=debug)
         self.inverted = inverted
 
     # Functions specific to Shutter
 
     ## Setting and getting slots for Slider approach
-    def get_slot(self):
+    def get_slot(self) -> int | None:
         """Finds at which slot the slider is at the moment."""
         status = self.get("position")
         slot = self.extract_slot_from_status(status)
         return slot
 
-    def set_slot(self, slot):
+    def set_slot(self, slot: int) -> int | None:
         """Moves the slider to a particular slot."""
         # If the slider is elsewhere, move it.
         if slot == 1:
@@ -34,7 +37,7 @@ class Shutter(Motor):
         else:
             return None
 
-    def jog(self, direction="forward"):
+    def jog(self, direction: str = "forward") -> int | None:
         """Jogs by the jog distance in a particular direction."""
         if direction in ["backward", "forward"]:
             status = self.move(direction)
@@ -44,28 +47,28 @@ class Shutter(Motor):
             return None
 
     ## Opening and closing for Shutter approach
-    def open(self):
+    def open(self) -> int | None:
         """Opens the shutter. Actual position depends on whether or not inverted=True is
         passed to the shutter at creation.
         """
         return self.set_slot(1 if self.inverted else 2)
 
-    def close(self):
+    def close(self) -> int | None:
         """Closes the shutter. Actual position depends on whether or not inverted=True is
         passed to the shutter at creation.
         """
         return self.set_slot(2 if self.inverted else 1)
 
-    def is_open(self):
+    def is_open(self) -> bool:
         """Returns True if shutter is open, False if closed."""
         return self.get_slot() == (1 if self.inverted else 2)
 
-    def is_closed(self):
+    def is_closed(self) -> bool:
         """Returns True if shutter is closed, False if open."""
         return self.get_slot() == (2 if self.inverted else 1)
 
     # Helper functions
-    def extract_slot_from_status(self, status):
+    def extract_slot_from_status(self, status: Status | None) -> int | None:
         """Extracts slot from status."""
         # If status is telling us current position
         if status:
@@ -76,14 +79,14 @@ class Shutter(Motor):
 
         return None
 
-    def pos_to_slot(self, posval):
+    def pos_to_slot(self, posval: int) -> int:
         """Converts position value to slot number."""
         slots = devices[self.motor_type]["slots"]
         factor = self.range / (slots - 1)
         slot = int(posval / factor) + 1
         return slot
 
-    def slot_to_pos(self, slot):
+    def slot_to_pos(self, slot: int) -> int:
         """Converts slot number to position value."""
         slots = devices[self.motor_type]["slots"]
         factor = self.range / (slots - 1)

--- a/src/elliptec/slider.py
+++ b/src/elliptec/slider.py
@@ -1,29 +1,33 @@
 """Module for slider stages. Inherits from elliptec.Motor."""
+from __future__ import annotations
+
+from .controller import Controller
 from .devices import devices
+from .tools import Status
 from . import Motor
 
 
 class Slider(Motor):
     """Slider class for elliptec devices. Inherits from elliptec.Motor."""
 
-    def __init__(self, controller, address="0", debug=True):
+    def __init__(self, controller: Controller, address: str = "0", debug: bool = True) -> None:
         super().__init__(controller=controller, address=address, debug=debug)
 
     ## Setting and getting slots
-    def get_slot(self):
+    def get_slot(self) -> int | None:
         """Finds at which slot the slider is at the moment."""
         status = self.get("position")
         slot = self.extract_slot_from_status(status)
         return slot
 
-    def set_slot(self, slot):
+    def set_slot(self, slot: int) -> int | None:
         """Moves the slider to a particular slot."""
         position = self.slot_to_pos(slot)
         status = self.move("absolute", position)
         slot = self.extract_slot_from_status(status)
         return slot
 
-    def jog(self, direction="forward"):
+    def jog(self, direction: str = "forward") -> int | None:
         """Jogs by the jog distance in a particular direction."""
         if direction in ["backward", "forward"]:
             status = self.move(direction)
@@ -33,7 +37,7 @@ class Slider(Motor):
             return None
 
     # Helper functions
-    def extract_slot_from_status(self, status):
+    def extract_slot_from_status(self, status: Status | None) -> int | None:
         """Extracts slot from status."""
         # If status is telling us current position
         if status:
@@ -44,7 +48,7 @@ class Slider(Motor):
 
         return None
 
-    def pos_to_slot(self, posval, accuracy=5):
+    def pos_to_slot(self, posval: int, accuracy: int = 5) -> int | None:
         """Converts position value to slot number."""
         positions = devices[self.motor_type]["positions"]
         closest_position = min(positions, key=lambda x: abs(x - posval))
@@ -54,7 +58,7 @@ class Slider(Motor):
             slot = positions.index(closest_position) + 1
             return slot
 
-    def slot_to_pos(self, slot):
+    def slot_to_pos(self, slot: int) -> int | None:
         """Converts slot number to position value."""
         positions = devices[self.motor_type]["positions"]
         # If slot within range


### PR DESCRIPTION
## Summary
- Type hints added across all modules
- print() replaced with logging
- Motor inherits from ABC; ContinuousMotor uses @abstractmethod
- Internal utils removed from public API
- py.typed PEP 561 marker added
- Docs: badges, typo fixes, version/copyright updates