### PR TITLE
Configure Read the Docs for automated documentation builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds Read the Docs configuration and documentation build dependencies to enable automated documentation generation and hosting.

## Key Changes
- Added `.readthedocs.yaml` configuration file specifying:
  - Ubuntu 22.04 build environment
  - Python 3.12 runtime
  - Sphinx documentation configuration from `docs/source/conf.py`
  - Documentation dependencies from `docs/requirements.txt`
- Created `docs/requirements.txt` with Sphinx and Read the Docs theme dependencies
- Fixed Python path in `docs/source/conf.py` to correctly reference the project root (changed from `../` to `../../`)

## Implementation Details
The path adjustment in `conf.py` was necessary because the Sphinx configuration file is located in `docs/source/`, so it needs to traverse up two directory levels to reach the project root, rather than just one.