### PR TITLE
Reorganize codecov configuration structure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,10 @@
 comment: false
 
+codecov:
+  notify:
+    after_n_builds: 1
+    wait_for_ci: false
+
 coverage:
   status:
     project:
@@ -9,15 +14,5 @@ coverage:
       default:
         target: auto
 
-notify:
-  after_n_builds: 1
-  wait_for_ci: false
-
 github_checks:
   annotations: false
-
-slack:
-  default: false
-
-email:
-  default: false


### PR DESCRIPTION
## Summary
Restructured the codecov.yml configuration file to improve organization and reduce notification noise by consolidating settings under a clearer hierarchy.

## Key Changes
- Moved `notify` configuration under a new top-level `codecov` section for better logical grouping
- Removed `slack` notification configuration (set to `default: false`)
- Removed `email` notification configuration (set to `default: false`)
- Kept all active coverage and GitHub checks configurations intact

## Implementation Details
The notification settings (`after_n_builds: 1` and `wait_for_ci: false`) remain functionally identical but are now nested under `codecov.notify` instead of a standalone `notify` section. This aligns with codecov's recommended configuration structure and reduces clutter by removing disabled notification channels that were explicitly set to false.
