### PR TITLE
Run tests on push to main and master branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions test workflow to run on push events in addition to pull requests, ensuring continuous testing on the main development branches.

## Key Changes
- Modified the workflow trigger configuration to run tests on `push` events to `main` and `master` branches
- Maintained existing `pull_request` trigger to continue testing all pull requests

## Implementation Details
The workflow now uses an expanded `on` configuration that explicitly specifies:
- Push events filtered to the `main` and `master` branches
- Pull request events (all branches)

This ensures that commits pushed directly to the main branches are tested immediately, improving code quality assurance and catching issues earlier in the development cycle.