### PR TITLE
Update Ko-fi donation button image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Some of the missing functionality can be performed using the official [Elliptec&
 ## Support
 If you are going to use this code in any way, **please let me know** via [email](mailto:roesel@gmail.com)/[twitter](https://twitter.com/DavidRoesel)/[issues](https://github.com/roesel/elliptec/issues) or find my contact info on [my website](https://david.roesel.cz/en/). I am working on this project in my spare time and need every piece of encouragement I can get! If this project was useful to you, please consider buying me a coffee ;).
 
-<a href='https://ko-fi.com/roesel' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+<a href='https://ko-fi.com/roesel' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://storage.ko-fi.com/cdn/kofi2.png?v=3' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 ## Disclaimer
 Thorlabs&trade; and Elliptec&trade; are registered trademarks of Thorlabs,&nbsp;Inc. This project is fully non-commercial and not affiliated with Thorlabs,&nbsp;Inc. in any capacity. 


### PR DESCRIPTION
## Summary
Updates the Ko-fi donation button image URL in the README to use the current CDN endpoint and image version.

## Changes
- Updated Ko-fi button image source from `az743702.vo.msecnd.net/cdn/kofi3.png?v=0` to `storage.ko-fi.com/cdn/kofi2.png?v=3`
- This ensures the donation button displays correctly with the latest Ko-fi CDN infrastructure

## Details
The Ko-fi CDN endpoint has been updated to their current storage domain. This change maintains the functionality of the donation link while using the proper, up-to-date image resource.